### PR TITLE
Apply Chefstyle to train-aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Gemfile.local
 Gemfile.local.lock
+Gemfile.lock
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,7 @@
-# encoding: utf-8
 source 'https://rubygems.org'
 
-# This is Gemfile, which is used by bundler
-# to ensure a coherent set of gems is installed.
-# This file lists dependencies needed when outside
-# of a gem (the gemspec lists deps for gem deployment)
-
-# Bundler should refer to the gemspec for any dependencies.
 gemspec
 
-# Remaining group is only used for development.
 group :development do
   gem 'pry'
   gem 'bundler'
@@ -18,5 +10,5 @@ group :development do
   gem 'mocha'
   gem 'm'
   gem 'rake'
-  gem 'rubocop', '= 0.49.1' # Need to keep in sync with main InSpec project, so config files will work
+  gem 'chefstyle'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
 group :development do
-  gem 'pry'
-  gem 'bundler'
-  gem 'byebug'
-  gem 'minitest'
-  gem 'mocha'
-  gem 'm'
-  gem 'rake'
-  gem 'chefstyle'
+  gem "pry"
+  gem "bundler"
+  gem "byebug"
+  gem "minitest"
+  gem "mocha"
+  gem "m"
+  gem "rake"
+  gem "chefstyle"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,6 @@ end
 # #------------------------------------------------------------------#
 require "chefstyle"
 require "rubocop/rake_task"
-RuboCop::RakeTask.new do |task|
+RuboCop::RakeTask.new(:lint) do |task|
     task.options << "--display-cop-names"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -32,15 +32,8 @@ end
 # #------------------------------------------------------------------#
 # #                    Code Style Tasks
 # #------------------------------------------------------------------#
-# require 'rubocop/rake_task'
-
-# RuboCop::RakeTask.new(:lint) do |t|
-#   # Choices of rubocop rules to enforce are deeply personal.
-#   # Here, we set things up so that your plugin will use the Bundler-installed
-#   # train gem's copy of the Train project's rubocop.yml file (which
-#   # is indeed packaged with the train gem).
-#   require 'train/globals'
-#   train_rubocop_yml = File.join(Train.src_root, '.rubocop.yml')
-
-#   t.options = ['--display-cop-names', '--config', train_rubocop_yml]
-# end
+require "chefstyle"
+require "rubocop/rake_task"
+RuboCop::RakeTask.new do |task|
+    task.options << "--display-cop-names"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -11,17 +11,17 @@ task default: [:'test:unit', :'test:functional']
 #------------------------------------------------------------------#
 #                    Test Runner Tasks
 #------------------------------------------------------------------#
-require 'rake/testtask'
+require "rake/testtask"
 
 namespace :test do
   {
-    unit: 'test/unit/*_test.rb',
-    functional: 'test/integration/*_test.rb',
-    integration: 'test/function/*_test.rb',
+    unit: "test/unit/*_test.rb",
+    functional: "test/integration/*_test.rb",
+    integration: "test/function/*_test.rb",
   }.each do |task_name, glob|
     Rake::TestTask.new(task_name) do |t|
-      t.libs.push 'lib'
-      t.libs.push 'test'
+      t.libs.push "lib"
+      t.libs.push "test"
       t.test_files = FileList[glob]
       t.verbose = true
       t.warning = false
@@ -35,5 +35,5 @@ end
 require "chefstyle"
 require "rubocop/rake_task"
 RuboCop::RakeTask.new(:lint) do |task|
-    task.options << "--display-cop-names"
+  task.options << "--display-cop-names"
 end

--- a/lib/train-aws.rb
+++ b/lib/train-aws.rb
@@ -12,10 +12,10 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 # It's traditonal to keep your gem version in a separate file, so CI can find it easier.
-require 'train-aws/version'
+require "train-aws/version"
 
 # A train plugin has three components: Transport, Connection, and Platform.
 # Transport acts as the glue.
-require 'train-aws/transport'
-require 'train-aws/platform'
-require 'train-aws/connection'
+require "train-aws/transport"
+require "train-aws/platform"
+require "train-aws/connection"

--- a/lib/train-aws/connection.rb
+++ b/lib/train-aws/connection.rb
@@ -14,27 +14,27 @@
 
 # Push platform detection out to a mixin, as it tends
 # to develop at a different cadence than the rest
-require 'train-aws/platform'
-require 'train'
-require 'train/plugins'
+require "train-aws/platform"
+require "train"
+require "train/plugins"
 
-require 'aws-sdk-core'
+require "aws-sdk-core"
 
-require 'aws-sdk-cloudtrail'
-require 'aws-sdk-cloudwatch'
-require 'aws-sdk-cloudwatchlogs'
-require 'aws-sdk-costandusagereportservice'
-require 'aws-sdk-configservice'
-require 'aws-sdk-ec2'
-require 'aws-sdk-ecs'
-require 'aws-sdk-eks'
-require 'aws-sdk-elasticloadbalancing'
-require 'aws-sdk-iam'
-require 'aws-sdk-kms'
-require 'aws-sdk-rds'
-require 'aws-sdk-s3'
-require 'aws-sdk-sqs'
-require 'aws-sdk-sns'
+require "aws-sdk-cloudtrail"
+require "aws-sdk-cloudwatch"
+require "aws-sdk-cloudwatchlogs"
+require "aws-sdk-costandusagereportservice"
+require "aws-sdk-configservice"
+require "aws-sdk-ec2"
+require "aws-sdk-ecs"
+require "aws-sdk-eks"
+require "aws-sdk-elasticloadbalancing"
+require "aws-sdk-iam"
+require "aws-sdk-kms"
+require "aws-sdk-rds"
+require "aws-sdk-s3"
+require "aws-sdk-sqs"
+require "aws-sdk-sns"
 
 module TrainPlugins
   module Aws
@@ -58,7 +58,7 @@ module TrainPlugins
         options[:region] = options[:host] || options[:region]
         if options[:path]
           # string the leading / from path
-          options[:profile] = options[:path].sub(%r{^/}, '')
+          options[:profile] = options[:path].sub(%r{^/}, "")
         end
 
         # Now let the BaseConnection have a chance to configure itself.
@@ -69,8 +69,8 @@ module TrainPlugins
 
         # Why are we doing this?
         # Why aren't we calling the AWS config system?
-        ENV['AWS_PROFILE'] = @options[:profile] if @options[:profile]
-        ENV['AWS_REGION'] = @options[:region] if @options[:region]
+        ENV["AWS_PROFILE"] = @options[:profile] if @options[:profile]
+        ENV["AWS_REGION"] = @options[:region] if @options[:region]
       end
 
       # We support caching on the aws_client call, but not the aws_resource call

--- a/lib/train-aws/platform.rb
+++ b/lib/train-aws/platform.rb
@@ -20,7 +20,7 @@ module TrainPlugins::Aws
       # of the cloud family.
 
       # This plugin defines a new platform.
-      Train::Platforms.name('aws').in_family('cloud')
+      Train::Platforms.name("aws").in_family("cloud")
 
       # When you know you will only ever run on your dedicated platform
       # force_platform! lets you bypass platform detection.
@@ -29,11 +29,11 @@ module TrainPlugins::Aws
       # Use release to report a version number.  You might use the version
       # of the plugin, or a version of an important underlying SDK, or a
       # version of a remote API.
-      aws_version = Gem.loaded_specs['aws-sdk-core'].version
+      aws_version = Gem.loaded_specs["aws-sdk-core"].version
       aws_version = "aws-sdk-core: v#{aws_version}"
       plugin_version = "train-aws: v#{TrainPlugins::Aws::VERSION}"
 
-      force_platform!('aws', release: "#{plugin_version}, #{aws_version}")
+      force_platform!("aws", release: "#{plugin_version}, #{aws_version}")
     end
   end
 end

--- a/lib/train-aws/transport.rb
+++ b/lib/train-aws/transport.rb
@@ -1,30 +1,30 @@
 
-require 'train'
-require 'train/plugins'
-require 'aws-sdk-core'
+require "train"
+require "train/plugins"
+require "aws-sdk-core"
 
 # Train Plugins v1 are usually declared under the TrainPlugins namespace.
 # Each plugin has three components: Transport, Connection, and Platform.
 # We'll only define the Transport here, but we'll refer to the others.
-require 'train-aws/connection'
+require "train-aws/connection"
 
 module TrainPlugins
   module Aws
     class Transport < Train.plugin(1)
-      name 'aws'
+      name "aws"
 
       # Pass ENV vars in using a block to `option`.  This causes `
       # option to lazy-evaluate the block to provide a default value.`
       # Otherwise, we would read the ENV var (and set the default)
       # once at compile time, which would make testing difficult.
       # TODO: convert to thor-style defaults
-      option(:region, required: true) { ENV['AWS_REGION'] }
-      option(:access_key_id) { ENV['AWS_ACCESS_KEY_ID'] }
-      option(:secret_access_key) { ENV['AWS_SECRET_ACCESS_KEY'] }
-      option(:session_token) { ENV['AWS_SESSION_TOKEN'] }
+      option(:region, required: true) { ENV["AWS_REGION"] }
+      option(:access_key_id) { ENV["AWS_ACCESS_KEY_ID"] }
+      option(:secret_access_key) { ENV["AWS_SECRET_ACCESS_KEY"] }
+      option(:session_token) { ENV["AWS_SESSION_TOKEN"] }
 
       # This can provide the access key id and secret access key
-      option(:profile) { ENV['AWS_PROFILE'] }
+      option(:profile) { ENV["AWS_PROFILE"] }
 
       # The only thing you MUST do in a transport is a define a
       # connection() method that returns a instance that is a

--- a/test/functional/train-aws_test.rb
+++ b/test/functional/train-aws_test.rb
@@ -7,45 +7,45 @@
 # their app. Unlike unit tests, we don't assume any knowledge of how anything
 # works; we just know what it is supposed to do.
 
-require_relative '../helper'
-require 'train'
+require_relative "../helper"
+require "train"
 
 # Train should auto-load train-aws
 # require 'train-aws'
 
-describe 'train-aws' do
+describe "train-aws" do
   describe "creating a train instance with this transport" do
     it "should not explode on create" do
       # This checks for uncaught exceptions.
-      Train.create('aws', {})
+      Train.create("aws", {})
 
       # This checks for warnings (or any other output) to stdout/stderr
-      proc { Train.create('aws') }.must_be_silent
+      proc { Train.create("aws") }.must_be_silent
     end
   end
 
-  describe 'creating a connection object using the transport' do
+  describe "creating a connection object using the transport" do
     it "should not explode on connect" do
       # This checks for uncaught exceptions.
-      Train.create('aws').connection
+      Train.create("aws").connection
 
       # This checks for warnings (or any other output) to stdout/stderr
-      proc { Train.create('aws').connection }.must_be_silent
+      proc { Train.create("aws").connection }.must_be_silent
     end
   end
 
   describe "reading a file" do
     it "should throw an exception if you try to read a file" do
-      conn = Train.create('aws').connection
-      path = File.join('nonesuch' + rand.to_s)
+      conn = Train.create("aws").connection
+      path = File.join("nonesuch" + rand.to_s)
       proc { conn.file(path).contents }.must_raise(NotImplementedError)
     end
   end
 
   describe "running a command" do
     it "should throw an exception if you try to run a command" do
-      conn = Train.create('aws').connection
-      proc { conn.run_command('date') }.must_raise(NotImplementedError)
+      conn = Train.create("aws").connection
+      proc { conn.run_command("date") }.must_raise(NotImplementedError)
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,15 +4,15 @@
 # any utilities to make testing a plugin easier.
 
 # require 'train/plugin_test_helper'
-require 'minitest/spec'
-require 'minitest/mock'
-require 'mocha/minitest'
-require 'minitest/autorun'
+require "minitest/spec"
+require "minitest/mock"
+require "mocha/minitest"
+require "minitest/autorun"
 
 class Module
   include Minitest::Spec::DSL
 end
 
 # Common debugging tools
-require 'pry'
-require 'byebug'
+require "pry"
+require "byebug"

--- a/test/integration/live_connect_test.rb
+++ b/test/integration/live_connect_test.rb
@@ -12,98 +12,96 @@
 # To use this test, you must have in your ~/.aws/credentials:
 #  * whatever profile you mention in the env var AWS_PROFILE
 
-require 'train'
-require_relative '../helper'
-require 'aws-sdk-core'
+require "train"
+require_relative "../helper"
+require "aws-sdk-core"
 
 # On load, scrape all AWS_* ENV vars out and store them
 # We'll re-inject them as needed
 ORIG_AWS_ENV_VARS = ENV.keys.each_with_object({}) do |var_name, acc|
-  if var_name.start_with?('AWS')
+  if var_name.start_with?("AWS")
     acc[var_name] = ENV.delete(var_name)
   end
   acc
 end
 
-describe 'Live-fire conenctions to AWS' do
+describe "Live-fire conenctions to AWS" do
   # Purge ENV prior to each test
   before do
-    ENV.delete_if { |var_name, _| var_name.start_with?('AWS') }
+    ENV.delete_if { |var_name, _| var_name.start_with?("AWS") }
 
     skip "Bad ENV!" unless ORIG_AWS_ENV_VARS.size >= 4
   end
 
-  let(:key_id) {ORIG_AWS_ENV_VARS['AWS_ACCESS_KEY_ID']}
-  let(:secret_key) {ORIG_AWS_ENV_VARS['AWS_SECRET_ACCESS_KEY']}
-  let(:region) {ORIG_AWS_ENV_VARS['AWS_REGION']}
-  let(:profile) {ORIG_AWS_ENV_VARS['AWS_PROFILE']}
+  let(:key_id) { ORIG_AWS_ENV_VARS["AWS_ACCESS_KEY_ID"] }
+  let(:secret_key) { ORIG_AWS_ENV_VARS["AWS_SECRET_ACCESS_KEY"] }
+  let(:region) { ORIG_AWS_ENV_VARS["AWS_REGION"] }
+  let(:profile) { ORIG_AWS_ENV_VARS["AWS_PROFILE"] }
 
-
-
-  describe 'that use a variety of authentication methods' do
-    let(:transport_options) { { backend: 'aws' } }
-    let(:transport) { Train.create('aws', transport_options) }
+  describe "that use a variety of authentication methods" do
+    let(:transport_options) { { backend: "aws" } }
+    let(:transport) { Train.create("aws", transport_options) }
     let(:connection) { transport.connection }
     let(:uuid) { connection.unique_identifier }
 
     # Common errors:
     # Aws::Errors::MissingCredentialsError Exception: unable to sign request without credentials set
 
-    it 'works correctly using a target URI with region and profile' do
+    it "works correctly using a target URI with region and profile" do
       transport_options = Train.unpack_target_from_uri("aws://#{region}/#{profile}")
       # TODO: figure out why memoizing these with let: breaks the test
-      transport = Train.create('aws', transport_options)
-      connection =  transport.connection
+      transport = Train.create("aws", transport_options)
+      connection = transport.connection
       uuid = connection.unique_identifier
       uuid.length.must_equal 12
     end
 
-    it 'works correctly using region and profile directly passed in' do
-      transport = Train.create('aws', region: region, profile: profile)
-      connection =  transport.connection
+    it "works correctly using region and profile directly passed in" do
+      transport = Train.create("aws", region: region, profile: profile)
+      connection = transport.connection
       uuid = connection.unique_identifier
       uuid.length.must_equal 12
     end
 
-    it 'works correctly when the profile and region are in the ENV' do
-      ENV['AWS_REGION'] = region
-      ENV['AWS_PROFILE'] = profile
+    it "works correctly when the profile and region are in the ENV" do
+      ENV["AWS_REGION"] = region
+      ENV["AWS_PROFILE"] = profile
       uuid.length.must_equal 12
     end
 
-    it 'works correctly when the key and region are in the ENV' do
-      ENV['AWS_REGION'] = region
-      ENV['AWS_ACCESS_KEY_ID'] = key_id
-      ENV['AWS_SECRET_ACCESS_KEY'] = secret_key
+    it "works correctly when the key and region are in the ENV" do
+      ENV["AWS_REGION"] = region
+      ENV["AWS_ACCESS_KEY_ID"] = key_id
+      ENV["AWS_SECRET_ACCESS_KEY"] = secret_key
       uuid.length.must_equal 12
     end
 
     # TODO: session key
   end
 
-  describe 'that access a variety of services via Clients' do
+  describe "that access a variety of services via Clients" do
     # It is important to test each of these, since the gem depends on
     # each service on a gem-by-gem basis.  The Connection must load
     # all the services.
     {
-      'cloudtrail' => { client: :CloudTrail, call: :describe_trails, duck: :trail_list },
-      'cloudwatch' => {client: :CloudWatch, call: :describe_alarms, duck: :metric_alarms },
-      'cloudwatchlogs' => {client: :CloudWatchLogs, call: :describe_log_groups, duck: :log_groups },
-      'billing' => {client: :CostandUsageReportService, call: :describe_report_definitions, duck: :report_definitions },
-      'config' => {client: :ConfigService, call: :describe_config_rules, duck: :config_rules },
-      'ec2' => {client: :EC2, call: :describe_instances, duck: :reservations },
-      'ecs' => {client: :ECS, call: :list_clusters, duck: :cluster_arns },
-      'eks' => {client: :EKS, call: :list_clusters, duck: :clusters },
-      'elb' => {client: :ElasticLoadBalancing, call: :describe_load_balancers, duck: :load_balancer_descriptions },
-      'iam' => {client: :IAM, call: :list_groups, duck: :groups },
-      'KMS' => {client: :KMS, call: :list_keys, duck: :keys },
-      'RDS' => {client: :RDS, call: :describe_db_instances, duck: :db_instances },
-      'S3' => {client: :S3, call: :list_buckets, duck: :buckets },
-      'SQS' => {client: :SQS, call: :list_queues, duck: :queue_urls },
-      'SNS' => {client: :SNS, call: :list_topics, duck: :topics },
+      "cloudtrail" => { client: :CloudTrail, call: :describe_trails, duck: :trail_list },
+      "cloudwatch" => { client: :CloudWatch, call: :describe_alarms, duck: :metric_alarms },
+      "cloudwatchlogs" => { client: :CloudWatchLogs, call: :describe_log_groups, duck: :log_groups },
+      "billing" => { client: :CostandUsageReportService, call: :describe_report_definitions, duck: :report_definitions },
+      "config" => { client: :ConfigService, call: :describe_config_rules, duck: :config_rules },
+      "ec2" => { client: :EC2, call: :describe_instances, duck: :reservations },
+      "ecs" => { client: :ECS, call: :list_clusters, duck: :cluster_arns },
+      "eks" => { client: :EKS, call: :list_clusters, duck: :clusters },
+      "elb" => { client: :ElasticLoadBalancing, call: :describe_load_balancers, duck: :load_balancer_descriptions },
+      "iam" => { client: :IAM, call: :list_groups, duck: :groups },
+      "KMS" => { client: :KMS, call: :list_keys, duck: :keys },
+      "RDS" => { client: :RDS, call: :describe_db_instances, duck: :db_instances },
+      "S3" => { client: :S3, call: :list_buckets, duck: :buckets },
+      "SQS" => { client: :SQS, call: :list_queues, duck: :queue_urls },
+      "SNS" => { client: :SNS, call: :list_topics, duck: :topics },
     }.each do |service_name, test_args|
       it "should be able to access the '#{service_name}' service" do
-        connection = Train.create('aws', region: region, profile: profile).connection
+        connection = Train.create("aws", region: region, profile: profile).connection
         service_module = ::Aws.const_get(test_args[:client])
         client_class = service_module.const_get(:Client)
         client = connection.aws_client(client_class)

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -2,10 +2,10 @@
 # Its job is to verify that the Connection class is setup correctly.
 
 # Include our test harness
-require_relative '../helper'
+require_relative "../helper"
 
 # Load the class under test, the Connection definition.
-require 'train-aws/connection'
+require "train-aws/connection"
 
 # Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
@@ -23,7 +23,7 @@ describe TrainPlugins::Aws::Connection do
   # Objects, and begin with 'must' (positive) or 'wont' (negative)
   # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
 
-  describe 'connection definition' do
+  describe "connection definition" do
 
     it "should inherit from the Train Connection base" do
       # For Class, '<' means 'is a descendant of'
@@ -42,10 +42,9 @@ describe TrainPlugins::Aws::Connection do
     end
   end
 
-
   # As an API-type plugin, we get to decide how to talk to our API.
 
-  describe 'API-SDK interface' do
+  describe "API-SDK interface" do
     # We use the aws-sdk, which provides two metaphors for accessing AWS objects:
     # a client-based approach (which focuses on explicit API calls) and a
     # resource-based approach  (which allows you to ask for all EC2 instances,
@@ -60,11 +59,11 @@ describe TrainPlugins::Aws::Connection do
       end
     end
 
-    describe 'aws_client' do
+    describe "aws_client" do
       # The aws_client call simply instantiates a Class that you provide.
       # Normally, that would be something like Aws::Iam::Client.
       # For testing, we're just passing Object.
-      it 'should instantiate things and cache them when caching is enabled' do
+      it "should instantiate things and cache them when caching is enabled" do
         connection.enable_cache(:api_call) # Just being explicit; this is the default
         client_one = connection.aws_client(Object)
         client_one.is_a?(Object).must_equal true
@@ -73,7 +72,7 @@ describe TrainPlugins::Aws::Connection do
         client_one.must_equal client_two
       end
 
-      it 'should instantiate things without caching them when caching is disabled' do
+      it "should instantiate things without caching them when caching is disabled" do
         connection.disable_cache(:api_call)
         client_one = connection.aws_client(Object)
         client_one.is_a?(Object).must_equal true
@@ -83,7 +82,7 @@ describe TrainPlugins::Aws::Connection do
       end
     end
 
-    describe 'aws_resource' do
+    describe "aws_resource" do
       class DummyAwsResource
         attr_reader :args
         def initialize(args)
@@ -93,9 +92,9 @@ describe TrainPlugins::Aws::Connection do
 
       # Current behavior is to never cache in resource mode, for fear of blowing memory.
       # We could be more sophisticated and limit the cache size. PRs welcome.
-      describe 'when caching is enabled' do
-        it 'should cache miss on a resource when the args match' do
-          resource_args = { user: 1, name: 'test_user' }
+      describe "when caching is enabled" do
+        it "should cache miss on a resource when the args match" do
+          resource_args = { user: 1, name: "test_user" }
           resource_one = connection.aws_resource(DummyAwsResource, resource_args)
           resource_one.args.must_equal resource_args
 
@@ -107,10 +106,9 @@ describe TrainPlugins::Aws::Connection do
     end
   end
 
-
   # Train connections need to be able to generate a UUID for targets.
   # train-aws uses the account ID.
-  describe 'uuid facility' do
+  describe "uuid facility" do
     class AwsCallerId
       def account
         "123456789012"
@@ -123,9 +121,9 @@ describe TrainPlugins::Aws::Connection do
       end
     end
 
-    it 'returns an account id' do
+    it "returns an account id" do
       connection.stubs(:aws_client).returns(StsClient.new)
-      connection.unique_identifier.must_equal '123456789012'
+      connection.unique_identifier.must_equal "123456789012"
     end
   end
 end

--- a/test/unit/credentials_test.rb
+++ b/test/unit/credentials_test.rb
@@ -4,21 +4,21 @@
 # most operations, the plugin must handle obtaining AWS credentials in various ways.
 
 # Include our test harness
-require 'helper'
+require "helper"
 
-describe 'AWS credential handling' do
+describe "AWS credential handling" do
   # Note: we re-declare test_options in several blocks
   let(:given_options) { nil }
 
   let(:transport) do
-    ENV['AWS_REGION'] = 'fixture_region_from_env'
-    ENV['AWS_ACCESS_KEY_ID'] = 'fixture_key_id_from_env'
-    ENV['AWS_PROFILE'] = 'fixture_profile_from_env'
-    ENV['AWS_SECRET_ACCESS_KEY'] = 'fixture_access_key_from_env'
-    ENV['AWS_SESSION_TOKEN'] = 'fixture_session_token_from_env'
+    ENV["AWS_REGION"] = "fixture_region_from_env"
+    ENV["AWS_ACCESS_KEY_ID"] = "fixture_key_id_from_env"
+    ENV["AWS_PROFILE"] = "fixture_profile_from_env"
+    ENV["AWS_SECRET_ACCESS_KEY"] = "fixture_access_key_from_env"
+    ENV["AWS_SESSION_TOKEN"] = "fixture_session_token_from_env"
 
     # need to load this here as it captures the envs on load
-    load 'train-aws/transport.rb'
+    load "train-aws/transport.rb"
     TrainPlugins::Aws::Transport.new(given_options)
   end
 
@@ -26,34 +26,33 @@ describe 'AWS credential handling' do
   let(:observed_options) { connection.instance_variable_get(:@options) }
   let(:cache) { connection.instance_variable_get(:@cache) }
 
-  describe 'when no options provided' do
-    it 'defaults to env options' do
-      observed_options[:region].must_equal 'fixture_region_from_env'
-      observed_options[:access_key_id].must_equal 'fixture_key_id_from_env'
-      observed_options[:profile].must_equal 'fixture_profile_from_env'
-      observed_options[:secret_access_key].must_equal 'fixture_access_key_from_env'
-      observed_options[:session_token].must_equal 'fixture_session_token_from_env'
+  describe "when no options provided" do
+    it "defaults to env options" do
+      observed_options[:region].must_equal "fixture_region_from_env"
+      observed_options[:access_key_id].must_equal "fixture_key_id_from_env"
+      observed_options[:profile].must_equal "fixture_profile_from_env"
+      observed_options[:secret_access_key].must_equal "fixture_access_key_from_env"
+      observed_options[:session_token].must_equal "fixture_session_token_from_env"
     end
   end
 
-  describe 'when given AWS-specific options' do
-    let(:given_options) {{ region: 'overidden_region', access_key_id: 'overidden_key' }}
+  describe "when given AWS-specific options" do
+    let(:given_options) { { region: "overidden_region", access_key_id: "overidden_key" } }
 
-    it 'should override defaults when given options' do
-      observed_options[:region].must_equal 'overidden_region'
-      observed_options[:access_key_id].must_equal 'overidden_key'
+    it "should override defaults when given options" do
+      observed_options[:region].must_equal "overidden_region"
+      observed_options[:access_key_id].must_equal "overidden_key"
       # These were not overridden
-      observed_options[:profile].must_equal 'fixture_profile_from_env'
-      observed_options[:secret_access_key].must_equal 'fixture_access_key_from_env'
-      observed_options[:session_token].must_equal 'fixture_session_token_from_env'
+      observed_options[:profile].must_equal "fixture_profile_from_env"
+      observed_options[:secret_access_key].must_equal "fixture_access_key_from_env"
+      observed_options[:session_token].must_equal "fixture_session_token_from_env"
     end
   end
 
+  describe "when parsing a URL" do
+    let(:given_options) { { host: "region_from_url", path: "profile_from_url" } }
 
-  describe 'when parsing a URL' do
-    let(:given_options) {{ host: 'region_from_url', path: 'profile_from_url' }}
-
-    it 'should handle options resulting from a parsed URL' do
+    it "should handle options resulting from a parsed URL" do
       # Train accepts target options in the form of URLs.
       # For AWS, the URI looks like:
       #  aws://region/profile_name
@@ -61,9 +60,9 @@ describe 'AWS credential handling' do
       # URI parts as a URL with host, path, etc.
       # train-aws takes those parsed pieces and re-labels them according
       # to AWS credential components.
-      observed_options[:region].must_equal 'region_from_url'
-      observed_options[:profile].must_equal 'profile_from_url'
-      observed_options[:session_token].must_equal 'fixture_session_token_from_env'
+      observed_options[:region].must_equal "region_from_url"
+      observed_options[:profile].must_equal "profile_from_url"
+      observed_options[:session_token].must_equal "fixture_session_token_from_env"
     end
   end
 

--- a/test/unit/platform_test.rb
+++ b/test/unit/platform_test.rb
@@ -2,30 +2,30 @@
 # Its job is to verify that platform detection is setup correctly.
 
 # Include our test harness
-require_relative '../helper'
+require_relative "../helper"
 
 # Load the class under test, the Connection definition.
 # We're actually testig the Platform module, but it's exposed via the Connection.
-require 'train-aws/connection'
+require "train-aws/connection"
 
 # Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
 describe TrainPlugins::Aws::Platform do
-  it 'should implement a platform method' do
+  it "should implement a platform method" do
     TrainPlugins::Aws::Platform.instance_methods(false).must_include(:platform)
   end
 
   it "should force platform to 'aws'" do
     plat = TrainPlugins::Aws::Connection.new({}).platform
-    plat.name.must_equal 'aws'
+    plat.name.must_equal "aws"
     plat.linux?.must_equal false
     plat.cloud?.must_equal true
-    plat.family.must_equal 'cloud'
-    plat.family_hierarchy.must_equal ['cloud', 'api']
+    plat.family.must_equal "cloud"
+    plat.family_hierarchy.must_equal %w{cloud api}
   end
 
-  it 'provides api details in the platform data' do
-    aws_version = Gem.loaded_specs['aws-sdk-core'].version
+  it "provides api details in the platform data" do
+    aws_version = Gem.loaded_specs["aws-sdk-core"].version
     aws_version = "aws-sdk-core: v#{aws_version}"
     plugin_version = "train-aws: v#{TrainPlugins::Aws::VERSION}"
     expected_release = "#{plugin_version}, #{aws_version}"

--- a/test/unit/transport_test.rb
+++ b/test/unit/transport_test.rb
@@ -2,10 +2,10 @@
 # Its job is to verify that the Transport class is setup correctly.
 
 # Include our test harness
-require_relative '../helper'
+require_relative "../helper"
 
 # Load the class under test, the Plugin definition.
-require 'train-aws/transport'
+require "train-aws/transport"
 
 # Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
@@ -21,12 +21,12 @@ describe TrainPlugins::Aws::Transport do
   # Objects, and begin with 'must' (positive) or 'wont' (negative)
   # See https://ruby-doc.org/stdlib-2.1.0/libdoc/minitest/rdoc/MiniTest/Expectations.html
 
-  describe 'plugin definition' do
+  describe "plugin definition" do
 
     it "should be registered with the plugin registry without the train- prefix" do
      # Note that Train uses String keys here, not Symbols
-     Train::Plugins.registry.keys.wont_include('train-aws')
-     Train::Plugins.registry.keys.must_include('aws')
+      Train::Plugins.registry.keys.wont_include("train-aws")
+      Train::Plugins.registry.keys.must_include("aws")
     end
 
     it "should inherit from the Train plugin base" do
@@ -40,10 +40,10 @@ describe TrainPlugins::Aws::Transport do
     end
   end
 
-  describe 'Transport Options' do
+  describe "Transport Options" do
     let(:transport) { plugin_class.new }
 
-    it 'should have the correct options' do
+    it "should have the correct options" do
       [
         :access_key_id,
         :profile,

--- a/train-aws.gemspec
+++ b/train-aws.gemspec
@@ -4,22 +4,22 @@
 
 # It is traditional in a gemspec to dynamically load the current version
 # from a file in the source tree.  The next three lines make that happen.
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'train-aws/version'
+require "train-aws/version"
 
 Gem::Specification.new do |spec|
   # Importantly, all Train plugins must be prefixed with `train-`
-  spec.name          = 'train-aws'
+  spec.name          = "train-aws"
 
   # It is polite to namespace your plugin under InspecPlugins::YourPluginInCamelCase
   spec.version       = TrainPlugins::Aws::VERSION
-  spec.authors       = ['Chef InSpec Team']
-  spec.email         = ['inspec@chef.io']
+  spec.authors       = ["Chef InSpec Team"]
+  spec.email         = ["inspec@chef.io"]
   spec.summary       = "AWS API Transport for Train"
-  spec.description   = 'Allows applictaions using Train to speak to AWS; handles authentication, cacheing, and SDK dependency management.'
-  spec.homepage      = 'https://github.com/inspec/train-aws'
-  spec.license       = 'Apache-2.0'
+  spec.description   = "Allows applictaions using Train to speak to AWS; handles authentication, cacheing, and SDK dependency management."
+  spec.homepage      = "https://github.com/inspec/train-aws"
+  spec.license       = "Apache-2.0"
 
   # Though complicated-looking, this is pretty standard for a gemspec.
   # It just filters what will actually be packaged in the gem (leaving
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.files = %w{
     README.md train-aws.gemspec Gemfile
   } + Dir.glob(
-    'lib/**/*', File::FNM_DOTMATCH
+    "lib/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
   # If you rely on any other gems, list them here with any constraints.
   # This is how `inspec plugin install` is able to manage your dependencies.
@@ -39,25 +39,25 @@ Gem::Specification.new do |spec|
 
   # Do not list inspec as a dependency of a train plugin.
 
-  spec.add_dependency 'train', '~> 2.0'
-  spec.add_dependency 'aws-sdk-autoscaling', '~> 1.22.0'
-  spec.add_dependency 'aws-sdk-core', '~> 3.0'
-  spec.add_dependency 'aws-sdk-cloudtrail', '~> 1.8'
-  spec.add_dependency 'aws-sdk-cloudwatch', '~> 1.13'
-  spec.add_dependency 'aws-sdk-cloudwatchlogs', '~> 1.13'
-  spec.add_dependency 'aws-sdk-configservice', '~> 1.21'
-  spec.add_dependency 'aws-sdk-costandusagereportservice', '~> 1.6'
-  spec.add_dependency 'aws-sdk-dynamodb', '~> 1.31'
-  spec.add_dependency 'aws-sdk-ec2', '~> 1.70'
-  spec.add_dependency 'aws-sdk-ecr', '~> 1.18'
-  spec.add_dependency 'aws-sdk-ecs', '~> 1.30'
-  spec.add_dependency 'aws-sdk-eks', '~> 1.9'
-  spec.add_dependency 'aws-sdk-elasticloadbalancing', '~> 1.8'
-  spec.add_dependency 'aws-sdk-iam', '~> 1.13'
-  spec.add_dependency 'aws-sdk-kms', '~> 1.13'
-  spec.add_dependency 'aws-sdk-organizations', '~> 1.17.0'
-  spec.add_dependency 'aws-sdk-rds', '~> 1.43'
-  spec.add_dependency 'aws-sdk-s3', '~> 1.30'
-  spec.add_dependency 'aws-sdk-sns', '~> 1.9'
-  spec.add_dependency 'aws-sdk-sqs', '~> 1.10'
+  spec.add_dependency "train", "~> 2.0"
+  spec.add_dependency "aws-sdk-autoscaling", "~> 1.22.0"
+  spec.add_dependency "aws-sdk-core", "~> 3.0"
+  spec.add_dependency "aws-sdk-cloudtrail", "~> 1.8"
+  spec.add_dependency "aws-sdk-cloudwatch", "~> 1.13"
+  spec.add_dependency "aws-sdk-cloudwatchlogs", "~> 1.13"
+  spec.add_dependency "aws-sdk-configservice", "~> 1.21"
+  spec.add_dependency "aws-sdk-costandusagereportservice", "~> 1.6"
+  spec.add_dependency "aws-sdk-dynamodb", "~> 1.31"
+  spec.add_dependency "aws-sdk-ec2", "~> 1.70"
+  spec.add_dependency "aws-sdk-ecr", "~> 1.18"
+  spec.add_dependency "aws-sdk-ecs", "~> 1.30"
+  spec.add_dependency "aws-sdk-eks", "~> 1.9"
+  spec.add_dependency "aws-sdk-elasticloadbalancing", "~> 1.8"
+  spec.add_dependency "aws-sdk-iam", "~> 1.13"
+  spec.add_dependency "aws-sdk-kms", "~> 1.13"
+  spec.add_dependency "aws-sdk-organizations", "~> 1.17.0"
+  spec.add_dependency "aws-sdk-rds", "~> 1.43"
+  spec.add_dependency "aws-sdk-s3", "~> 1.30"
+  spec.add_dependency "aws-sdk-sns", "~> 1.9"
+  spec.add_dependency "aws-sdk-sqs", "~> 1.10"
 end


### PR DESCRIPTION
This sync's the train-aws repo with the centralized chefstyle used by all Chef projects.