### PR TITLE
Remove invalid Expeditor project alias line

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -4,8 +4,6 @@
 slack:
   notify_channel: inspec-notify
 
-project: inspec/train-aws:master
-
 # This publish is triggered by the `built_in:publish_rubygems` artifact_action.
 rubygems:
   - train-aws


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The `project:` line was a string; it should be a hash. We don't actually use any of those setting, so I removed it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #20

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
