### PR TITLE
Move train dependency to Gemfile from gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "train-core", "~> 3.0"
+
 group :development do
   gem "pry"
   gem "bundler"

--- a/train-aws.gemspec
+++ b/train-aws.gemspec
@@ -38,8 +38,8 @@ Gem::Specification.new do |spec|
   # them in Gemfile, not here.
 
   # Do not list inspec as a dependency of a train plugin.
+  # Do not list train as a dependency of a train plugin.
 
-  spec.add_dependency "train", "~> 2.0"
   # spec.add_dependency "aws-sdk-acm", "~> 1"
   # spec.add_dependency "aws-sdk-acmpca", "~> 1"
   # spec.add_dependency "aws-sdk-alexaforbusiness", "~> 1"


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This moves the dependencies on train into the Gemfile; without this, all train plugins must agree on train constraints for the inspec package when we ship it.

Also increments the allowed upper version to < 4; v3 has no changes that break this plugin.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
