### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/train-aws.rb
+++ b/lib/train-aws.rb
@@ -12,10 +12,10 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 # It's traditonal to keep your gem version in a separate file, so CI can find it easier.
-require "train-aws/version"
+require_relative "train-aws/version"
 
 # A train plugin has three components: Transport, Connection, and Platform.
 # Transport acts as the glue.
-require "train-aws/transport"
-require "train-aws/platform"
-require "train-aws/connection"
+require_relative "train-aws/transport"
+require_relative "train-aws/platform"
+require_relative "train-aws/connection"

--- a/lib/train-aws/connection.rb
+++ b/lib/train-aws/connection.rb
@@ -14,7 +14,7 @@
 
 # Push platform detection out to a mixin, as it tends
 # to develop at a different cadence than the rest
-require "train-aws/platform"
+require_relative "platform"
 require "train"
 require "train/plugins"
 

--- a/lib/train-aws/platform.rb
+++ b/lib/train-aws/platform.rb
@@ -1,4 +1,4 @@
-require "train-aws/version"
+require_relative "version"
 
 # Platform definition file.  This is a good place to separate out any
 # logic regarding the identification of the OS or API at the far end

--- a/lib/train-aws/transport.rb
+++ b/lib/train-aws/transport.rb
@@ -6,7 +6,7 @@ require "aws-sdk-core"
 # Train Plugins v1 are usually declared under the TrainPlugins namespace.
 # Each plugin has three components: Transport, Connection, and Platform.
 # We'll only define the Transport here, but we'll refer to the others.
-require "train-aws/connection"
+require_relative "connection"
 
 module TrainPlugins
   module Aws


### PR DESCRIPTION
require_relative is significantly faster and should be used when available. See @lamont-granquist for the full story.

Signed-off-by: Tim Smith <tsmith@chef.io>