### PR TITLE
Drop ruby 2.4, add ruby 3; get Ruby 2.5 working

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -23,7 +23,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-stretch
+        image: ruby:2.7
 
 - label: run-tests-ruby-3.0
   command:
@@ -31,4 +31,4 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.0-stretch
+        image: ruby:3.0

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,14 +1,6 @@
 ---
 steps:
 
-- label: run-tests-ruby-2.4
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-stretch
-
 - label: run-tests-ruby-2.5
   command:
     - /workdir/.expeditor/buildkite/verify.sh
@@ -31,4 +23,12 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-rc
+        image: ruby:2.7-stretch
+
+- label: run-tests-ruby-3.0
+  command:
+    - /workdir/.expeditor/buildkite/verify.sh
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0-stretch

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 gemspec
 
 gem "train-core", "~> 3.0"
+if Gem.ruby_version.to_s.start_with?("2.5")
+  # 16.7.23 required ruby 2.6+
+  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
+end
 
 group :development do
   gem "pry"


### PR DESCRIPTION
## Description

Adjustments to the CI testing - drops EOL Ruby 2.4 from testing, and adds Ruby 3.0. 
Also fixes Ruby 2.5 testing by conditionally pinning `chef-utils`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
