### PR TITLE
added aws-sdk-ecrpublic to gemspec

### DIFF
--- a/train-aws.gemspec
+++ b/train-aws.gemspec
@@ -98,6 +98,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-ec2", "~> 1.70"
   # spec.add_dependency "aws-sdk-ec2instanceconnect", "~> 1.0"
   spec.add_dependency "aws-sdk-ecr", "~> 1.18"
+  spec.add_dependency "aws-sdk-ecrpublic", "~> 1.3"
   spec.add_dependency "aws-sdk-ecs", "~> 1.30"
   spec.add_dependency "aws-sdk-efs", "~> 1.0"
   spec.add_dependency "aws-sdk-eks", "~> 1.9"


### PR DESCRIPTION
Signed-off-by: Gift

## Description
Added new run time dependency "aws-sdk-ecrpublic" to gem spec

## Related Issue
Can not use new aws feature ecrpublic without this dependent added to train-as

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
