### PR TITLE
Updating expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,27 +22,29 @@ github:
 changelog:
   rollup_header: Changes not yet released to rubygems.org
 
+subscriptions:
 # These actions are taken, in the order they are specified, anytime a Pull Request is merged.
-merge_actions:
-  - built_in:bump_version:
-      ignore_labels:
-        - "CI/Skip Version Bump"
-        - "CI/Skip All"
-  - bash:.expeditor/update_version.sh:
-      only_if:
-        - built_in:bump_version
-  - built_in:update_changelog:
-      ignore_labels:
-        - "CI/Skip Changelog"
-        - "CI/Skip All"
-  - built_in:build_gem:
-      only_if:
-        - built_in:bump_version
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+      - built_in:bump_version:
+         ignore_labels:
+          - "CI/Skip Version Bump"
+          - "CI/Skip All"
+      - bash:.expeditor/update_version.sh:
+         only_if:
+          - built_in:bump_version
+      - built_in:update_changelog:
+         ignore_labels:
+          - "CI/Skip Changelog"
+          - "CI/Skip All"
+      - built_in:build_gem:
+         only_if:
+          - built_in:bump_version
 
-promote:
-  actions:
-    - built_in:rollover_changelog
-    - built_in:publish_rubygems
+  - workload: project_promoted:{{agent_id}}:*
+    actions:
+     - built_in:rollover_changelog
+     - built_in:publish_rubygems
 
 pipelines:
   - verify:


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
i) The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity.
ii)  The promote block has been deprecated. All actions should be declared via the subscriptions block for clarity.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
