### PR TITLE
RESOURCE-204 update train-aws tests to use ruby versions 2.7 and 3.0 only

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,14 +1,6 @@
 ---
 steps:
 
-- label: lint-ruby-3.0
-  command:
-    - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0
-
 - label: run-tests-ruby-2.7
   command:
     - RAKE_TASK=default /workdir/.expeditor/buildkite/verify.sh

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,25 +1,17 @@
 ---
 steps:
 
-- label: run-tests-ruby-2.5
+- label: lint-ruby-3.0
   command:
-    - /workdir/.expeditor/buildkite/verify.sh
+    - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
   expeditor:
     executor:
       docker:
-        image: ruby:2.5-stretch
-
-- label: run-tests-ruby-2.6
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-stretch
+        image: ruby:3.0
 
 - label: run-tests-ruby-2.7
   command:
-    - /workdir/.expeditor/buildkite/verify.sh
+    - RAKE_TASK=default /workdir/.expeditor/buildkite/verify.sh
   expeditor:
     executor:
       docker:
@@ -27,7 +19,7 @@ steps:
 
 - label: run-tests-ruby-3.0
   command:
-    - /workdir/.expeditor/buildkite/verify.sh
+    - RAKE_TASK=default /workdir/.expeditor/buildkite/verify.sh
   expeditor:
     executor:
       docker:


### PR DESCRIPTION
Removes Ruby 2.5 and 2.6 (EOL) from CI testing.

No linting checks.