### PR TITLE
adding aws-sdk-macie2 given aws-sdk-macie is going EOL

### DIFF
--- a/train-aws.gemspec
+++ b/train-aws.gemspec
@@ -153,6 +153,7 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "aws-sdk-lightsail", "~> 1.84.0"
   # spec.add_dependency "aws-sdk-machinelearning", "~> 1.49.0"
   spec.add_dependency "aws-sdk-macie", "~> 1.48.0"
+  spec.add_dependency "aws-sdk-macie2", "~> 1.64.0"
   # spec.add_dependency "aws-sdk-managedblockchain", "~> 1.48.0"
   # spec.add_dependency "aws-sdk-marketplacecommerceanalytics", "~> 1.53.0"
   # spec.add_dependency "aws-sdk-marketplaceentitlementservice", "~> 1.47.0"

--- a/train-aws.gemspec
+++ b/train-aws.gemspec
@@ -152,7 +152,6 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "aws-sdk-licensemanager", "~> 1.53.0"
   # spec.add_dependency "aws-sdk-lightsail", "~> 1.84.0"
   # spec.add_dependency "aws-sdk-machinelearning", "~> 1.49.0"
-  spec.add_dependency "aws-sdk-macie", "~> 1.48.0"
   spec.add_dependency "aws-sdk-macie2", "~> 1.64.0"
   # spec.add_dependency "aws-sdk-managedblockchain", "~> 1.48.0"
   # spec.add_dependency "aws-sdk-marketplacecommerceanalytics", "~> 1.53.0"

--- a/train-aws.gemspec
+++ b/train-aws.gemspec
@@ -152,7 +152,7 @@ Gem::Specification.new do |spec|
   # spec.add_dependency "aws-sdk-licensemanager", "~> 1.53.0"
   # spec.add_dependency "aws-sdk-lightsail", "~> 1.84.0"
   # spec.add_dependency "aws-sdk-machinelearning", "~> 1.49.0"
-  spec.add_dependency "aws-sdk-macie2", "~> 1.64.0"
+  spec.add_dependency "aws-sdk-macie2", "~> 1.64.0" 
   # spec.add_dependency "aws-sdk-managedblockchain", "~> 1.48.0"
   # spec.add_dependency "aws-sdk-marketplacecommerceanalytics", "~> 1.53.0"
   # spec.add_dependency "aws-sdk-marketplaceentitlementservice", "~> 1.47.0"


### PR DESCRIPTION
Given AWS is updating the Macie service, the inspec-aws macie resources will use tthe new aws-sdk-macie2 gem.

Signed-off-by: Aaron Lippold <lippold@gmail.com>