### PR TITLE
Remove chef-utils dependency added for Ruby 2.5 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "train-core", "~> 3.0"
-if Gem.ruby_version.to_s.start_with?("2.5")
-  # 16.7.23 required ruby 2.6+
-  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
-end
 
 group :development do
   gem "pry"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Remove chef-utils library dependency.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
